### PR TITLE
feature: Add settings for CTA visibility and demo URL appending

### DIFF
--- a/iwp-demo-helper.php
+++ b/iwp-demo-helper.php
@@ -179,7 +179,9 @@ class IWP_Migration {
 		wp_enqueue_script( 'iwp-migration', plugin_dir_url( __FILE__ ) . 'js/scripts.js', array( 'jquery' ), time() );
 		wp_localize_script( 'iwp-migration', 'iwp_migration',
 			array(
-				'ajax_url' => admin_url( 'admin-ajax.php' ),
+				'ajax_url'              => admin_url( 'admin-ajax.php' ),
+				'demo_site_url'         => site_url(),
+				'enable_src_demo_url'   => IWP_Migration::get_option( 'iwp_enable_src_demo_url', '' ),
 			)
 		);
 
@@ -364,6 +366,18 @@ class IWP_Migration {
 				'title'       => 'Custom CSS',
 				'type'        => 'css_editor',
 				'placeholder' => '/* Enter your custom CSS here */',
+			),
+			'iwp_hide_cta_button' => array(
+				'title' => 'Hide CTA Button',
+				'label' => 'Hide CTA Button on migration page',
+				'type' => 'checkbox',
+				'default' => '',
+			),
+			'iwp_enable_src_demo_url' => array(
+				'title' => 'Enable src_demo_url',
+				'label' => 'Append src_demo_url parameter to links in Main Content',
+				'type' => 'checkbox',
+				'default' => '',
 			),
 			'iwp_hide_migration_plugin' => array(
 				'title'   => 'Hide Migration Plugin',

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -59,5 +59,20 @@
         });
     });
 
+    // New code for appending src_demo_url
+    if ($('body.admin_page_iwp_migrate_content').length > 0 && plugin_object.enable_src_demo_url === 'yes') {
+        var demoUrl = plugin_object.demo_site_url;
+        if (demoUrl) { // Ensure demoUrl is not empty
+            $('.migration-desc a').each(function () {
+                var link = $(this);
+                var currentHref = link.attr('href');
+                if (currentHref && currentHref !== '#' && !currentHref.startsWith('javascript:')) { // Basic check to avoid modifying empty or JS links
+                    var paramSeparator = currentHref.indexOf('?') === -1 ? '?' : '&';
+                    var newHref = currentHref + paramSeparator + 'src_demo_url=' + encodeURIComponent(demoUrl);
+                    link.attr('href', newHref);
+                }
+            });
+        }
+    }
 })(jQuery, window, document, iwp_migration);
 

--- a/templates/migration.php
+++ b/templates/migration.php
@@ -1,5 +1,6 @@
 <?php
 
+$hide_cta_button      = IWP_Migration::get_option( 'iwp_hide_cta_button', '' );
 $logo_url             = IWP_Migration::get_option( 'logo_url' );
 $title_text           = IWP_Migration::get_option( 'title_text' );
 $content              = IWP_Migration::get_option( 'content' );
@@ -38,9 +39,11 @@ $close_btn_bg_color   = IWP_Migration::get_option( 'close_btn_bg_color' );
                 </label>
 			<?php endif; ?>
 
+			<?php if ( $hide_cta_button !== 'yes' ) : ?>
             <button style="background-color:<?php echo esc_attr( $cta_btn_bg_color ); ?>; color:<?php echo esc_attr( $cta_btn_text_color ); ?>;" class="iwp-btn iwp-btn-migrate">
 				<?php echo esc_attr( $cta_btn_text ); ?>
             </button>
+			<?php endif; ?>
 
             <div class="iwp_migration_footer">
 				<?php echo wp_kses_post( $footer_text ); ?>


### PR DESCRIPTION
This commit introduces two new settings for the IWP Migration plugin:

1.  **Hide CTA Button**: A checkbox setting in the "IWP Migration Settings" page allows you to hide the main Call To Action button on the `page=iwp_migrate_content` migration page.
    *   The setting is labeled "Hide CTA Button on migration page".
    *   By default, the CTA button remains visible.
    *   The `templates/migration.php` file was updated to conditionally render the button based on this setting.

2.  **Enable `src_demo_url` Parameter**: A checkbox setting allows you to enable appending the demo website's URL as a GET parameter (`src_demo_url`) to all HTML links found within the "Main Content" section on the `page=iwp_migrate_content` page.
    *   The setting is labeled "Append src_demo_url parameter to links in Main Content".
    *   This feature is disabled by default.
    *   The `js/scripts.js` file was updated to:
        *   Check if this feature is enabled via a localized script variable.
        *   If enabled, iterate through links in the `.migration-desc` area.
        *   Append `src_demo_url=[SITE_URL]` to each link's href, correctly handling existing query parameters.
    *   The main plugin file `iwp-demo-helper.php` was updated to pass the current site URL and the status of this new setting to the JavaScript environment using `wp_localize_script`.

Both settings are added to the `get_setting_fields` method in `iwp-demo-helper.php` and are integrated into the existing settings framework.