### PR TITLE
Add expiry hours settings 

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Available placeholders:
 
 ## 📋 Changelog
 
-### v1.0.7 - 08 Aug 2025 🆕
+### v1.0.7 - 19 August 2025 🆕
 **Added:**
 - Reset Settings functionality with JavaScript-based form handling
 - Centralized default values system using DRY principle
@@ -190,6 +190,7 @@ Available placeholders:
 - API key security enhancements - only last 4 characters visible, no show functionality
 - Request/response logging with WP_DEBUG integration and sensitive data masking
 - Export/Import settings functionality with JSON format and WP-CLI commands
+- Extend Site Expiry settings to allow extending site expiration.
 
 **Fixed:**
 - Reset button form nesting issues preventing proper form submission

--- a/iwp-demo-helper.php
+++ b/iwp-demo-helper.php
@@ -4,6 +4,10 @@ Plugin Name: InstaWP Demo Helper
 Description: Enables one-click migration requests from demo WordPress sites. Adds a customizable migration button to the admin bar and provides a branded migration interface that connects to InstaWP's API for seamless site transfers. Perfect for hosting providers offering temporary demos with migration capabilities.
 Version: 1.0.7
 Author: InstaWP Inc
+Text Domain: iwp-demo-helper
+Domain Path: /languages
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
 */
 
 defined( 'IWP_MIG_PLUGIN_VERSION' ) || define( 'IWP_MIG_PLUGIN_VERSION', '1.0.7' );
@@ -213,9 +217,10 @@ class IWP_Migration {
 		$convert_sandbox = get_option( 'iwp_convert_sandbox' ) === 'yes';
 		$show_domain_redirect = get_option( 'iwp_show_domain_field' ) === 'yes';
 		$create_ticket = get_option( 'iwp_create_ticket' ) === 'yes';
+		$expiry_hours    = get_option( 'iwp_expiry_hours' );
 		
 		// Only proceed if at least one action is enabled
-		if ( ! $open_link_action && ! $convert_sandbox && ! $show_domain_redirect && ! $create_ticket ) {
+		if ( ! $open_link_action && ! $convert_sandbox && ! $show_domain_redirect && ! $create_ticket && empty( $expiry_hours ) ) {
 			wp_send_json_error( [ 'message' => 'No migration actions are enabled. Please enable at least one option in the settings.' ] );
 		}
 		
@@ -235,14 +240,19 @@ class IWP_Migration {
 		// Only make API call if convert_sandbox or create_ticket is enabled
 		$response_body = array( 'status' => true );
 		
-		if ( $convert_sandbox || $create_ticket ) {
+		if ( $convert_sandbox || $create_ticket || ! empty( $expiry_hours ) ) {
 			$body_args = array(
 				'url'            => site_url(),
 				'email'          => $create_ticket ? get_option( 'iwp_support_email' ) : '',
 				'customer_email' => get_option( 'admin_email' ),
 				'subject'        => $iwp_email_subject,
 				'body'           => $iwp_email_body,
+				'move_to_sites'  => $convert_sandbox,
 			);
+
+			if ( ! $convert_sandbox && ! empty( $expiry_hours ) ) {
+				$body_args['expiry_hours'] = (int) $expiry_hours;
+			}
 
 			$headers  = array(
 				'Accept'        => 'application/json',
@@ -575,6 +585,7 @@ class IWP_Migration {
 			// General Settings Tab
 			'iwp_api_key' => '',
 			'iwp_convert_sandbox' => 'yes',
+			'iwp_expiry_hours'          => '',
 			'iwp_create_ticket' => '', // Changed from 'yes' to '' (no)
 			'iwp_support_email' => '',
 			'iwp_open_link_action' => '', // Already '' (no)
@@ -636,6 +647,14 @@ class IWP_Migration {
 				'default' => $defaults['iwp_convert_sandbox'],
 				'tab'     => 'general',
 				'help'    => 'Automatically convert the sandbox to a regular site after migration request.',
+			),
+			'iwp_expiry_hours'          => array(
+				'title'       => 'Extend Site Expiry (in hours)',
+				'type'        => 'number',
+				'placeholder' => 'Enter expiry hours',
+				'default'     => $defaults['iwp_expiry_hours'],
+				'tab'         => 'general',
+				'help'        => 'Enter valid hours to extend site expiry.',
 			),
 			'iwp_create_ticket' => array(
 				'title'   => 'Create Support Ticket',
@@ -1023,6 +1042,10 @@ class IWP_Migration {
 
 		if ( $field_type === 'url' ) {
 			printf( '<input type="url" style="width: 380px;" name="%s" value="%s" placeholder="%s" />', $field_id, $field_value, $placeholder );
+		}
+
+		if ( $field_type === 'number' ) {
+			printf( '<input type="number" style="width: 380px;" name="%s" value="%s" placeholder="%s" />', $field_id, $field_value, $placeholder );
 		}
 
 		if ( $field_type === 'checkbox' ) {

--- a/iwp-demo-helper.php
+++ b/iwp-demo-helper.php
@@ -1,13 +1,13 @@
 <?php
-/*
-Plugin Name: InstaWP Demo Helper
-Description: Enables one-click migration requests from demo WordPress sites. Adds a customizable migration button to the admin bar and provides a branded migration interface that connects to InstaWP's API for seamless site transfers. Perfect for hosting providers offering temporary demos with migration capabilities.
-Version: 1.0.7
-Author: InstaWP Inc
-Text Domain: iwp-demo-helper
-Domain Path: /languages
-License: GPLv2 or later
-License URI: https://www.gnu.org/licenses/gpl-2.0.html
+/** 
+* Plugin Name: InstaWP Demo Helper
+* Description: Enables one-click migration requests from demo WordPress sites. Adds a customizable migration button to the admin bar and provides a branded migration interface that connects to InstaWP's API for seamless site transfers. Perfect for hosting providers offering temporary demos with migration capabilities.
+* Version: 		1.0.7
+* Author: 		InstaWP Inc
+* Author URI:  	https://instawp.com
+* License: 		GPLv2 or later
+* License URI: 	https://www.gnu.org/licenses/gpl-2.0.html
+* Text Domain: 	iwp-demo-helper
 */
 
 defined( 'IWP_MIG_PLUGIN_VERSION' ) || define( 'IWP_MIG_PLUGIN_VERSION', '1.0.7' );
@@ -247,11 +247,11 @@ class IWP_Migration {
 				'customer_email' => get_option( 'admin_email' ),
 				'subject'        => $iwp_email_subject,
 				'body'           => $iwp_email_body,
-				'move_to_sites'  => $convert_sandbox,
 			);
 
 			if ( ! $convert_sandbox && ! empty( $expiry_hours ) ) {
 				$body_args['expiry_hours'] = (int) $expiry_hours;
+				$body_args['move_to_sites'] = false;
 			}
 
 			$headers  = array(

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -9,6 +9,24 @@
             const currentTab = urlParams.get('tab') || 'general';
             localStorage.setItem('iwp_migration_current_tab', currentTab);
         }
+
+        // Conditional logic for expiry_hours
+        var convertSandboxCheckbox = $('input[name="iwp_convert_sandbox"]');
+        var expiryHoursRow = $('input[name="iwp_expiry_hours"]').closest('tr');
+
+        function toggleExpiryHours() {
+            if (convertSandboxCheckbox.is(':checked')) {
+                expiryHoursRow.hide();
+                $('input[name="iwp_expiry_hours"]').val('');
+            } else {
+                expiryHoursRow.show();
+            }
+        }
+
+        if (convertSandboxCheckbox.length) {
+            toggleExpiryHours();
+            convertSandboxCheckbox.on('change', toggleExpiryHours);
+        }
     });
 
     $(document).on('change', 'input.iwp-checkbox-with-field', function () {


### PR DESCRIPTION
This setting will be available when admin uncheck "Convert Sandbox to Regular Site" setting. It's value will be included in '/api/v2/migrate-request' API call along with {'move_to_sites ':false}. The mentioned API will also be called when "expiry_hours" has some valid value.